### PR TITLE
Remove recommendation to prefer TS over JS.

### DIFF
--- a/sections/javascript.md
+++ b/sections/javascript.md
@@ -1,11 +1,6 @@
 
 # JavaScript Coding Guidelines
 
-## Use TypeScript
-Prefer TypeScript over JavaScript for all new projects.
-
-When possible, use the `strict` compiler setting to opt in to strict null checks and improved flow analysis. This setting significantly improves the capabilities of TypeScript's tooling. It's usually prohibitively costly to migrate existing projects to pass the stricter requirements, so enable it when the project is bootstrapped.
-
 ## Use Strict Comparison Operators
 Using strict comparisons makes code more explicit by clarifying which specific values are expected. It also saves readers from having to memorize coercion rules.
 


### PR DESCRIPTION
I'd like to reopen the discussion on our use of TypeScript here. I think when we last discussed I was one of the only ones opposing it. We've had some team changes since then: I've moved to a project that uses JS (and have been much happier without TS); @jacobcarpenter, @salexander6, and @RobertBolender have moved to a project that uses TS and have been frustrated by it. It seems like we have a handful of developers who use and like TS, a handful who use and dislike TS, and a bunch who are indifferent or haven't been exposed to it.

My personal position remains that TS slows me down, does not prevent very many bugs, and harms readability by adding a lot of unnecessary noise to the code. It also causes frequent headaches and confusion when upgrading dependencies or tooling, consuming dependencies built using a different TS configuration, or adding dependencies that have no types or have incorrect/outdated types. This seems in line with the feedback I've received from others recently.

From what I've seen, I don't think the projects that are using TS are utilizing it very well. `any` and type casts are sprinkled everywhere as a way to circumvent the type system; it's rare for anyone to take the time to annotate dependencies that don't have typings; external data is assumed to conform to the type annotations without being validated; few projects use strict checking; etc.. If we want to broadly adopt this technology it seems to me like we need to identify someone willing to champion it and help educate developers on proper use, come up with migration plans, establish best practices and describe common pitfalls.

I don't want to use TS any more. I know others feel differently, and I want people to be able to use the tools they like. I propose removing the guideline entirely and giving teams freedom to use the language that they feel best suits their needs.