### PR TITLE
Use tab_width when indent_style is tab.

### DIFF
--- a/sections/csharp/editorconfig.md
+++ b/sections/csharp/editorconfig.md
@@ -6,8 +6,9 @@ The standard settings for `charset`, `end_of_line`, `insert_final_newline`, and 
 
 ```editorconfig
 [*.cs]
-indent_size = 4
+indent_size = tab
 indent_style = tab
+tab_width = 4
 ```
 
 We have always used tabs of width 4 for C#.

--- a/sections/csharp/files/.editorconfig
+++ b/sections/csharp/files/.editorconfig
@@ -1,6 +1,7 @@
 [*.cs]
-indent_size = 4
+indent_size = tab
 indent_style = tab
+tab_width = 4
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true

--- a/sections/csharp/files/UpdateEditorConfig.ps1
+++ b/sections/csharp/files/UpdateEditorConfig.ps1
@@ -1,4 +1,4 @@
 $text = [System.IO.File]::ReadAllText([System.IO.Path]::Combine($PSScriptRoot, "..", "editorconfig.md"))
 $code = [regex]::Split(-join [regex]::Matches($text, '```editorconfig\s*(.*?)```', 'SingleLine').foreach({$_.Groups[1].Value}), '\r?\n')
-$code = $code[0..2] + ($code[3..($code.Length - 1)] | Where-Object { $_ -ne '' } | Sort-Object)
+$code = $code[0..3] + ($code[4..($code.Length - 1)] | Where-Object { $_ -ne '' } | Sort-Object)
 [System.IO.File]::WriteAllText((Join-Path $PSScriptRoot ".editorconfig"), ($code -join "`n") + "`n")


### PR DESCRIPTION
Settings indent_size to tab and using tab_width is more correct, and prevents ReSharper from using spaces for indentation.