### PR TITLE
Apply repository conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
+# DO NOT EDIT: root convention
 root = true
 
-# DO NOT EDIT: root convention
 [*]
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
Conventions applied by [repo-conventions](https://github.com/Faithlife/RepoConventions):
- editorconfig-root
  - editorconfig-section
    - config-text-section