### PR TITLE
Apply repository conventions

### DIFF
--- a/.agents/skills/create-repo-conventions/SKILL.md
+++ b/.agents/skills/create-repo-conventions/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: create-repo-conventions
+description: Create or update conventions that are published by this repository.
+---
+
+# Create Repo Conventions
+
+Use this skill when authoring or updating published convention directories that other repositories consume through repo-conventions.
+
+## Goal
+
+Produce conventions with a stable published path, documented settings, and idempotent behavior that matches the repo-conventions contract.
+
+## When To Use This Skill
+
+- Use this skill when creating a new published convention directory.
+- Use this skill when editing `convention.yml`, `convention.ps1`, a convention-local `README.md`, or files that support those conventions.
+- Do not use this skill to wire a consuming repository up to existing conventions. Use `use-repo-conventions` for that.
+
+## Convention Model
+
+- A published convention directory may contain `convention.yml`, `convention.ps1`, or both.
+- If both files exist, repo-conventions applies `convention.yml` first and then executes `convention.ps1`.
+- Composite conventions are for composing other conventions.
+- Executable conventions are for inspecting repository state and rewriting files.
+- Convention references may carry `settings`, including propagated child settings resolved from parent settings in composite conventions.
+- See `docs/authoring-conventions.md` for the full authoring contract.
+
+## Authoring Workflow
+
+- Define the policy boundary first. Prefer one coherent convention over a grab bag of unrelated changes.
+- Decide whether the convention should be composite, executable, or both.
+- Inspect existing published conventions in the repository before introducing new structure or terminology.
+- Put the convention in the repository's established convention location instead of inventing a new layout for a one-off change.
+- Keep the public surface small: stable path, clearly named settings, predictable outputs.
+- Update documentation in the same change when the convention behavior or supported inputs change.
+
+## Writing `convention.yml`
+
+- Use `convention.yml` when the convention is purely composition.
+- Keep entries in the intended application order.
+- Use explicit local relative paths for conventions published from the same repository.
+- Keep settings shallow and JSON-serializable.
+- When propagating parent settings into child settings, use the supported `${{ settings.foo.bar }}` syntax.
+- Use `${{ readText("path") }}` only when the convention genuinely needs file-backed text in child settings.
+
+Example:
+
+```yaml
+conventions:
+  - path: ../dotnet-sdk
+    settings:
+      version: 10
+  - path: ../dotnet-slnx
+```
+
+## Writing `convention.ps1`
+
+- The script runs with `pwsh` from the root of the target Git repository, not from the convention directory.
+- The script receives one argument: the path to a JSON input file.
+- Use `$args[0]` to access the path to the JSON input file, since future versions may pass additional arguments.
+- The JSON input file contains a single `settings` property.
+- Read the JSON input file only if needed.
+- Make the script idempotent. A second successful run should produce no further changes.
+- Exit with code zero when the repository is already compliant or after successfully making it compliant; use a non-zero exit code only when the convention genuinely cannot complete.
+- Prefer deterministic file writes and stable ordering so reruns do not churn diffs.
+- Avoid interactive prompts, editor launches, or hidden machine-local dependencies.
+- Emit focused output that explains what the convention changed or why it failed.
+- Convention scripts are encouraged to create their own informative commits when the convention naturally consists of multiple meaningful steps or when the resulting history matters for follow-up tasks such as blame-ignore files.
+
+Minimal pattern:
+
+```powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$conventionInput = Get-Content -Raw $args[0] | ConvertFrom-Json
+$settings = $conventionInput.settings
+
+# Inspect the target repository and apply only the required changes.
+```
+
+Don't bother reading the input file if your convention doesn't have settings, but keep in mind that settings may be added later and the convention should continue to work.
+
+## Behavioral Constraints
+
+- On success, if the script does not create commits itself, repo-conventions will auto-commit tracked or untracked changes left behind by the executable convention.
+- On failure, repo-conventions will hard-reset the target repository back to the pre-convention HEAD.
+- Do not create formatting-only churn unless formatting is the actual purpose of the convention.
+
+## Documentation
+
+- Always include a `README.md` in the convention directory documenting the convention's purpose, supported settings, and any required tools or frameworks.
+- Keep repository-level consumer docs focused on using conventions; put authoring details in convention-local docs or `docs/authoring-conventions.md`.
+
+## Testing
+
+- Test the convention with Pester if possible.
+- Put Pester tests in the same directory as the convention they cover, e.g. `conventions/my-convention/convention.Tests.ps1`.
+- Verify behavior against a clean temporary repository.
+- Test both an already-compliant repository and a non-compliant repository.
+- Re-run after the first successful application to confirm idempotency.
+- If the convention has settings, exercise at least one non-default settings case.

--- a/.agents/skills/use-repo-conventions/SKILL.md
+++ b/.agents/skills/use-repo-conventions/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: use-repo-conventions
+description: Add or update convention references in a repository that uses repo-conventions.
+---
+
+# Use Repo Conventions
+
+Use this skill when adding or updating `.github/conventions.yml` in a repository that consumes conventions via repo-conventions.
+
+## Goal
+
+Configure a repository to apply the right conventions in the right order with minimal, maintainable configuration.
+
+## When To Use This Skill
+
+- Use this skill when the task is to wire an existing repository up to one or more conventions.
+- Use this skill when the task is to add or update convention references or settings in `.github/conventions.yml`.
+- Use this skill when the task is to configure PR automation for convention-generated pull requests.
+- Do not use this skill to author published conventions or edit `convention.ps1` / `convention.yml` inside convention directories. Use `create-repo-conventions` for that.
+
+## Configuration Model
+
+- The repository config file is `.github/conventions.yml`.
+- The file must contain a `conventions` sequence.
+- Each entry must include `path` and may include `settings` and `pull-request`.
+- The file may also include top-level `pull-request` settings.
+- Convention entries are resolved in declaration order.
+- Local convention paths start with `./` or `../` or `/` and are resolved relative to the containing configuration file.
+- Remote convention paths use `owner/repo/path@ref`.
+- If `@ref` is omitted, repo-conventions uses the head of the remote repository's default branch.
+- See `docs/configuration.md` for the full configuration surface.
+
+Example:
+
+```yaml
+conventions:
+  - path: Faithlife/CodingGuidelines/conventions/dotnet-sdk
+    settings:
+      version: 10
+  - path: Faithlife/CodingGuidelines/conventions/dotnet-slnx
+```
+
+## Usage Workflow
+
+- Inspect the repository for an existing `.github/conventions.yml` file and any files or workflows that already assume conventions are present.
+- Identify which conventions should be applied and whether they should be local or remote references.
+- Keep the configuration minimal: add only the conventions and settings needed for the repository.
+- Preserve the intended application order. Earlier conventions may affect later ones.
+- Prefer `repo-conventions add <path>` when the task is simply to append a convention reference without changing other settings.
+- If the repository uses `repo-conventions apply --open-pr`, configure `pull-request` metadata in `.github/conventions.yml` instead of editing published convention internals.
+- Keep consumer documentation focused on how the repository uses conventions; link to shared authoring docs rather than duplicating convention implementation details.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,22 +1,22 @@
 lockfile_version: '1'
-generated_at: '2026-04-28T18:49:15.554862+00:00'
-apm_version: 0.10.0
+generated_at: '2026-05-04T15:13:38.578079+00:00'
+apm_version: 0.12.1
 dependencies:
 - repo_url: Faithlife/RepoConventions
   host: github.com
-  resolved_commit: 44ab9b80645d406fc4c3b620457b775b28181fd0
+  resolved_commit: 52c4931235269d37f249f9755dbe7273e96354a7
   virtual_path: skills/create-repo-conventions
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .github/skills/create-repo-conventions
+  - .agents/skills/create-repo-conventions
   content_hash: sha256:11946d3a2cad4308f8861b54a19127b46ef722954c129b4d845ad54949933ddd
 - repo_url: Faithlife/RepoConventions
   host: github.com
-  resolved_commit: 44ab9b80645d406fc4c3b620457b775b28181fd0
+  resolved_commit: 52c4931235269d37f249f9755dbe7273e96354a7
   virtual_path: skills/use-repo-conventions
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .github/skills/use-repo-conventions
+  - .agents/skills/use-repo-conventions
   content_hash: sha256:303dacfb20f1e218b4078424ce337f56118b8742688b72b79a8789de975a90e6


### PR DESCRIPTION
Conventions applied by [repo-conventions](https://github.com/Faithlife/RepoConventions):
- agentic-repo
  - apm-install