### PR TITLE
Add repo-conventions-workflow convention

### DIFF
--- a/conventions/repo-conventions-workflow/README.md
+++ b/conventions/repo-conventions-workflow/README.md
@@ -1,0 +1,21 @@
+# repo-conventions-workflow
+
+This [convention](https://github.com/Faithlife/RepoConventions) installs a GitHub Actions workflow at `.github/workflows/conventions.yml` that automatically applies repository conventions on a weekly schedule and opens a pull request when changes are needed.
+
+## Usage
+
+```yaml
+conventions:
+  - path: Faithlife/CodingGuidelines/conventions/repo-conventions-workflow
+```
+
+After adding this convention and running `repo-conventions apply`, the workflow file will be created. The workflow:
+
+- Runs every Monday at 6:00 AM UTC
+- Can be triggered manually via `workflow_dispatch`
+- Installs the `repo-conventions` tool and runs `repo-conventions apply --open-pr`
+- Opens or updates a pull request when any convention changes are detected
+
+## Permissions
+
+The workflow requires `contents: write` and `pull-requests: write` permissions, which are set in the workflow file. No additional repository settings are needed when using the default `GITHUB_TOKEN`.

--- a/conventions/repo-conventions-workflow/convention.Tests.ps1
+++ b/conventions/repo-conventions-workflow/convention.Tests.ps1
@@ -1,0 +1,112 @@
+#requires -PSEdition Core
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'repo-conventions-workflow convention' {
+	BeforeAll {
+		$script:conventionScriptPath = Join-Path $PSScriptRoot 'convention.ps1'
+		$script:expectedWorkflowPath = Join-Path $PSScriptRoot 'files' 'conventions.yml'
+		$script:testHelpersPath = Join-Path $PSScriptRoot '..' 'scripts' 'TestHelpers.ps1'
+		. $script:testHelpersPath
+
+		function script:InvokeRepoConventionsWorkflowConvention {
+			param(
+				[Parameter(Mandatory = $true)]
+				[string] $TestDirectory
+			)
+
+			$inputPath = New-ConventionInputFile -Settings @{}
+			try {
+				return Invoke-ConventionScript -ScriptPath $script:conventionScriptPath -RepositoryRoot $TestDirectory -InputPath $inputPath
+			}
+			finally {
+				Remove-Item -LiteralPath $inputPath -ErrorAction SilentlyContinue
+			}
+		}
+	}
+
+	It 'creates .github/workflows/conventions.yml when it is missing' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			$output = InvokeRepoConventionsWorkflowConvention -TestDirectory $testDirectory
+			$workflowPath = Join-Path $testDirectory '.github/workflows/conventions.yml'
+			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+
+			(Test-Path -LiteralPath $workflowPath) | Should -Be $true
+			(Get-Content -LiteralPath $workflowPath -Raw) | Should -Be (Get-Content -LiteralPath $script:expectedWorkflowPath -Raw)
+			$status.Count | Should -Be 1
+			$status[0] | Should -Match '^\?\? \.github/workflows/conventions\.yml$'
+			(@($output | ForEach-Object { $_.ToString() }) -contains "Created '$workflowPath' from the published repo-conventions workflow.") | Should -Be $true
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+
+	It 'updates an existing conventions workflow to the published file' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+			$workflowPath = Join-Path $testDirectory '.github/workflows/conventions.yml'
+			New-Item -ItemType Directory -Path (Split-Path -Parent $workflowPath) -Force | Out-Null
+			Write-Utf8NoBomFile -Path $workflowPath -Content "name: Placeholder`n"
+
+			Push-Location $testDirectory
+			try {
+				& git add -A
+				& git commit -m 'Add placeholder workflow' | Out-Null
+			}
+			finally {
+				Pop-Location
+			}
+
+			$output = InvokeRepoConventionsWorkflowConvention -TestDirectory $testDirectory
+			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+
+			(Get-Content -LiteralPath $workflowPath -Raw) | Should -Be (Get-Content -LiteralPath $script:expectedWorkflowPath -Raw)
+			$status.Count | Should -Be 1
+			$status[0] | Should -Match '^ M \.github/workflows/conventions\.yml$'
+			(@($output | ForEach-Object { $_.ToString() }) -contains "Updated '$workflowPath' from the published repo-conventions workflow.") | Should -Be $true
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+
+	It 'is idempotent after the first successful application' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			InvokeRepoConventionsWorkflowConvention -TestDirectory $testDirectory | Out-Null
+
+			Push-Location $testDirectory
+			try {
+				& git add -A
+				& git commit -m 'Add conventions workflow' | Out-Null
+				$headAfterFirstRun = & git rev-parse HEAD
+			}
+			finally {
+				Pop-Location
+			}
+
+			$output = InvokeRepoConventionsWorkflowConvention -TestDirectory $testDirectory
+			$headAfterSecondRun = Get-CommitId -TestDirectory $testDirectory
+			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+
+			$headAfterSecondRun | Should -Be $headAfterFirstRun
+			$status.Count | Should -Be 0
+			$expectedWorkflowPath = Join-Path $testDirectory '.github' 'workflows' 'conventions.yml'
+			(@($output | ForEach-Object { $_.ToString() }) -contains "'$expectedWorkflowPath' already matches the published repo-conventions workflow.") | Should -Be $true
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+}

--- a/conventions/repo-conventions-workflow/convention.ps1
+++ b/conventions/repo-conventions-workflow/convention.ps1
@@ -1,0 +1,23 @@
+#requires -PSEdition Core
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$helpersPath = Join-Path $PSScriptRoot '..' 'scripts' 'Helpers.ps1'
+. $helpersPath
+
+Set-Utf8NoBomConsoleEncoding
+
+$sourceWorkflowPath = Join-Path $PSScriptRoot 'files' 'conventions.yml'
+$targetWorkflowPath = Join-Path (Get-Location) '.github/workflows/conventions.yml'
+$copyResult = Copy-FileIfDifferent -SourcePath $sourceWorkflowPath -DestinationPath $targetWorkflowPath
+
+if ($copyResult.Updated) {
+	Write-Host "Updated '$targetWorkflowPath' from the published repo-conventions workflow."
+}
+elseif ($copyResult.Created) {
+	Write-Host "Created '$targetWorkflowPath' from the published repo-conventions workflow."
+}
+else {
+	Write-Host "'$targetWorkflowPath' already matches the published repo-conventions workflow."
+}

--- a/conventions/repo-conventions-workflow/files/conventions.yml
+++ b/conventions/repo-conventions-workflow/files/conventions.yml
@@ -1,0 +1,33 @@
+name: Conventions
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+defaults:
+  run:
+    shell: pwsh
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install repo-conventions
+      run: dotnet tool install --global repo-conventions
+    - name: Apply conventions
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: repo-conventions apply --open-pr


### PR DESCRIPTION
## Problem

The `repo-conventions-workflow` convention is referenced in the RepoConventions README as the primary quickstart example, and is used in production by at least `Faithlife/FaithlifeFakeData` and `Faithlife/FaithlifeReflection`, but the convention directory does not exist in this repo. Running `repo-conventions apply` in any of those repos produces:

```
Convention 'Faithlife/CodingGuidelines/conventions/repo-conventions-workflow' directory '...' was not found.
```

## Solution

Adds the missing convention with the standard structure:
- `convention.ps1` — copies `files/conventions.yml` to `.github/workflows/conventions.yml`
- `files/conventions.yml` — workflow that runs `repo-conventions apply --open-pr` weekly (Mondays at 6 AM UTC) and on `workflow_dispatch`
- `convention.Tests.ps1` — three tests mirroring the pattern from `faithlife-build-library-workflow`
- `README.md` — usage and permissions docs