### PR TITLE
Add copilot-dotnet-format-hook and copilot-dotnet-standards conventions

### DIFF
--- a/conventions/copilot-dotnet-format-hook/README.md
+++ b/conventions/copilot-dotnet-format-hook/README.md
@@ -1,0 +1,31 @@
+# copilot-dotnet-format-hook
+
+Deploys a Copilot `postToolUse` hook that automatically runs `dotnet format` on any `.cs` file after it is edited or created by the agent.
+
+## What this convention does
+
+- Creates `.github/hooks/scripts/dotnet-format.ps1` in the target repository.
+- Merges a `postToolUse` hook entry into `.github/hooks/hooks.json` (creates the file if absent; preserves any existing hook entries).
+
+Both operations are idempotent. Running the convention again when files are already correct produces no changes.
+
+## Settings
+
+None. This convention has no configurable settings.
+
+## Requirements
+
+- `dotnet` CLI available in the environment where Copilot runs.
+- A `.sln` or project file that `dotnet format` can resolve from the repository root.
+
+## Files created or modified
+
+| Path | Description |
+|---|---|
+| `.github/hooks/scripts/dotnet-format.ps1` | Hook script that runs `dotnet format --include <file>` |
+| `.github/hooks/hooks.json` | Copilot hooks configuration; hook entry is merged in |
+
+## See also
+
+- Use `copilot-dotnet-standards` to install this convention together with the Roslyn LSP server and .NET coding standard instruction files in one step.
+- See [RepoConventions README](../../README.md) for general usage.

--- a/conventions/copilot-dotnet-format-hook/convention.Tests.ps1
+++ b/conventions/copilot-dotnet-format-hook/convention.Tests.ps1
@@ -1,0 +1,169 @@
+#requires -PSEdition Core
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'copilot-dotnet-format-hook convention' {
+	BeforeAll {
+		$script:conventionScriptPath = Join-Path $PSScriptRoot 'convention.ps1'
+		$script:expectedHookScriptPath = Join-Path $PSScriptRoot 'dotnet-format.ps1'
+		$script:testHelpersPath = Join-Path $PSScriptRoot '..' 'scripts' 'TestHelpers.ps1'
+		. $script:testHelpersPath
+
+		function script:InvokeConvention {
+			param(
+				[Parameter(Mandatory = $true)]
+				[string] $TestDirectory
+			)
+
+			return Invoke-ConventionScript -ScriptPath $script:conventionScriptPath -RepositoryRoot $TestDirectory
+		}
+
+		function script:GetOutputText {
+			param(
+				[Parameter(Mandatory = $true)]
+				[object[]] $Output
+			)
+
+			return (@($Output | ForEach-Object { $_.ToString() }) -join "`n")
+		}
+
+		function script:ReadHooksJson {
+			param(
+				[Parameter(Mandatory = $true)]
+				[string] $TestDirectory
+			)
+
+			$path = Join-Path $TestDirectory '.github' 'hooks' 'hooks.json'
+			return Get-Content -LiteralPath $path -Raw | ConvertFrom-Json -AsHashtable
+		}
+
+		$script:expectedHookEntry = @{
+			type = 'command'
+			bash = 'pwsh .github/hooks/scripts/dotnet-format.ps1'
+			powershell = '.github/hooks/scripts/dotnet-format.ps1'
+			cwd = '.'
+			timeoutSec = 30
+		}
+	}
+
+	It 'creates both files when neither exists' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			$output = InvokeConvention -TestDirectory $testDirectory
+
+			$hookScriptPath = Join-Path $testDirectory '.github' 'hooks' 'scripts' 'dotnet-format.ps1'
+			$hooksJsonPath = Join-Path $testDirectory '.github' 'hooks' 'hooks.json'
+			$hooksJson = ReadHooksJson -TestDirectory $testDirectory
+			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+			$outputText = GetOutputText -Output $output
+
+			(Test-Path -LiteralPath $hookScriptPath) | Should -Be $true
+			(Get-Content -LiteralPath $hookScriptPath -Raw) | Should -Be (Get-Content -LiteralPath $script:expectedHookScriptPath -Raw)
+			(Test-Path -LiteralPath $hooksJsonPath) | Should -Be $true
+			$hooksJson['hooks']['postToolUse'].Count | Should -Be 1
+			$hooksJson['hooks']['postToolUse'][0]['powershell'] | Should -Be '.github/hooks/scripts/dotnet-format.ps1'
+			$hooksJson['hooks']['postToolUse'][0]['bash'] | Should -Be 'pwsh .github/hooks/scripts/dotnet-format.ps1'
+			$hooksJson['hooks']['postToolUse'][0]['timeoutSec'] | Should -Be 30
+			$status.Count | Should -Be 1
+			$status[0] | Should -Match '^\?\? \.github/$'
+			$outputText | Should -Match "Created '\.github/hooks/scripts/dotnet-format\.ps1'\."
+			$outputText | Should -Match "Created '\.github/hooks/hooks\.json' with the dotnet-format hook\."
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+
+	It 'merges the hook entry when hooks.json already has other entries' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			$existingHooksDir = Join-Path $testDirectory '.github' 'hooks'
+			[System.IO.Directory]::CreateDirectory($existingHooksDir) | Out-Null
+
+			$existingHooksJson = @{
+				version = 1
+				hooks = @{
+					postToolUse = @(
+						@{
+							type = 'command'
+							bash = 'echo other-hook'
+							powershell = 'Write-Host other-hook'
+							cwd = '.'
+							timeoutSec = 10
+						}
+					)
+				}
+			}
+
+			$helpersPath = Join-Path $PSScriptRoot '..' 'scripts' 'Helpers.ps1'
+			. $helpersPath
+			Write-Utf8NoBomFile -Path (Join-Path $existingHooksDir 'hooks.json') -Content ($existingHooksJson | ConvertTo-Json -Depth 10)
+
+			$output = InvokeConvention -TestDirectory $testDirectory
+
+			$hooksJson = ReadHooksJson -TestDirectory $testDirectory
+			$postToolUse = $hooksJson['hooks']['postToolUse']
+			$outputText = GetOutputText -Output $output
+
+			$postToolUse.Count | Should -Be 2
+			$postToolUse[0]['powershell'] | Should -Be 'Write-Host other-hook'
+			$postToolUse[1]['powershell'] | Should -Be '.github/hooks/scripts/dotnet-format.ps1'
+			$outputText | Should -Match "Updated '\.github/hooks/hooks\.json' with the dotnet-format hook\."
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+
+	It 'is idempotent when both files are already correct' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			$null = InvokeConvention -TestDirectory $testDirectory
+			$statusAfterFirst = @(Get-GitStatusLines -TestDirectory $testDirectory)
+
+			$null = & git -C $testDirectory add -A
+			$null = & git -C $testDirectory commit -m 'Apply convention'
+
+			$output = InvokeConvention -TestDirectory $testDirectory
+			$statusAfterSecond = @(Get-GitStatusLines -TestDirectory $testDirectory)
+			$outputText = GetOutputText -Output $output
+
+			$statusAfterSecond.Count | Should -Be 0
+			$outputText | Should -Match "'\.github/hooks/scripts/dotnet-format\.ps1' is already up to date\."
+			$outputText | Should -Match "'\.github/hooks/hooks\.json' already contains the dotnet-format hook\."
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+
+	It 'produces no changes on a second run after compliance' {
+		$testDirectory = New-TestDirectory
+
+		try {
+			Initialize-TestRepository -Path $testDirectory
+
+			$null = InvokeConvention -TestDirectory $testDirectory
+			$null = & git -C $testDirectory add -A
+			$null = & git -C $testDirectory commit -m 'Apply convention'
+
+			$null = InvokeConvention -TestDirectory $testDirectory
+			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+
+			$status.Count | Should -Be 0
+		}
+		finally {
+			Remove-Item -LiteralPath $testDirectory -Recurse -Force
+		}
+	}
+}

--- a/conventions/copilot-dotnet-format-hook/convention.ps1
+++ b/conventions/copilot-dotnet-format-hook/convention.ps1
@@ -1,0 +1,118 @@
+#requires -PSEdition Core
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$helpersPath = Join-Path $PSScriptRoot '..' 'scripts' 'Helpers.ps1'
+. $helpersPath
+
+Set-Utf8NoBomConsoleEncoding
+
+$hookScriptSourcePath = Join-Path $PSScriptRoot 'dotnet-format.ps1'
+$hookScriptDestPath = Get-RepositoryPath -PathSetting '/.github/hooks/scripts/dotnet-format.ps1'
+$hookScriptDisplayPath = Format-RepositoryRelativePath -Path $hookScriptDestPath
+
+$scriptResult = Copy-FileIfDifferent -SourcePath $hookScriptSourcePath -DestinationPath $hookScriptDestPath
+
+if ($scriptResult.Created) {
+	Write-Host "Created '$hookScriptDisplayPath'."
+}
+elseif ($scriptResult.Updated) {
+	Write-Host "Updated '$hookScriptDisplayPath'."
+}
+else {
+	Write-Host "'$hookScriptDisplayPath' is already up to date."
+}
+
+$hooksJsonPath = Get-RepositoryPath -PathSetting '/.github/hooks/hooks.json'
+$hooksJsonDisplayPath = Format-RepositoryRelativePath -Path $hooksJsonPath
+
+$desiredHookEntry = [System.Text.Json.Nodes.JsonObject]::new()
+$desiredHookEntry['type'] = [System.Text.Json.Nodes.JsonValue]::Create('command')
+$desiredHookEntry['bash'] = [System.Text.Json.Nodes.JsonValue]::Create('pwsh .github/hooks/scripts/dotnet-format.ps1')
+$desiredHookEntry['powershell'] = [System.Text.Json.Nodes.JsonValue]::Create('.github/hooks/scripts/dotnet-format.ps1')
+$desiredHookEntry['cwd'] = [System.Text.Json.Nodes.JsonValue]::Create('.')
+$desiredHookEntry['timeoutSec'] = [System.Text.Json.Nodes.JsonValue]::Create(30)
+
+$hooksJsonFileExisted = Test-Path -LiteralPath $hooksJsonPath -PathType Leaf
+
+[System.Text.Json.Nodes.JsonObject] $rootObject = if ($hooksJsonFileExisted) {
+	try {
+		$parsed = [System.Text.Json.Nodes.JsonNode]::Parse((Get-Content -LiteralPath $hooksJsonPath -Raw))
+	}
+	catch {
+		throw "'$hooksJsonDisplayPath' does not contain valid JSON. $($_.Exception.Message)"
+	}
+
+	$asObject = $parsed -as [System.Text.Json.Nodes.JsonObject]
+	if ($null -eq $asObject) {
+		throw "'$hooksJsonDisplayPath' must contain a JSON object at the root."
+	}
+
+	, $asObject
+}
+else {
+	$newRoot = [System.Text.Json.Nodes.JsonObject]::new()
+	$newRoot['version'] = [System.Text.Json.Nodes.JsonValue]::Create(1)
+	$newRoot['hooks'] = [System.Text.Json.Nodes.JsonObject]::new()
+	, $newRoot
+}
+
+[System.Text.Json.Nodes.JsonNode] $hooksNode = $null
+$null = $rootObject.TryGetPropertyValue('hooks', [ref] $hooksNode)
+$hooksObject = $hooksNode -as [System.Text.Json.Nodes.JsonObject]
+
+if ($null -eq $hooksObject) {
+	$hooksObject = [System.Text.Json.Nodes.JsonObject]::new()
+	$rootObject['hooks'] = $hooksObject
+}
+
+[System.Text.Json.Nodes.JsonNode] $postToolUseNode = $null
+$null = $hooksObject.TryGetPropertyValue('postToolUse', [ref] $postToolUseNode)
+$postToolUseArray = $postToolUseNode -as [System.Text.Json.Nodes.JsonArray]
+
+if ($null -eq $postToolUseArray) {
+	$postToolUseArray = [System.Text.Json.Nodes.JsonArray]::new()
+	$hooksObject['postToolUse'] = $postToolUseArray
+}
+
+$alreadyPresent = $false
+foreach ($entry in $postToolUseArray) {
+	$entryObject = $entry -as [System.Text.Json.Nodes.JsonObject]
+	if ($null -eq $entryObject) {
+		continue
+	}
+
+	[System.Text.Json.Nodes.JsonNode] $powershellNode = $null
+	$null = $entryObject.TryGetPropertyValue('powershell', [ref] $powershellNode)
+
+	if ($powershellNode -is [System.Text.Json.Nodes.JsonValue] -and
+		$powershellNode.GetValue[string]() -eq '.github/hooks/scripts/dotnet-format.ps1') {
+		$alreadyPresent = $true
+		break
+	}
+}
+
+if ($alreadyPresent) {
+	Write-Host "'$hooksJsonDisplayPath' already contains the dotnet-format hook."
+	return
+}
+
+$null = $postToolUseArray.Add($desiredHookEntry)
+
+$hooksJsonDirectory = Split-Path -Parent $hooksJsonPath
+if (-not [string]::IsNullOrWhiteSpace($hooksJsonDirectory)) {
+	[System.IO.Directory]::CreateDirectory($hooksJsonDirectory) | Out-Null
+}
+
+$jsonOptions = [System.Text.Json.JsonSerializerOptions]::new()
+$jsonOptions.WriteIndented = $true
+$content = $rootObject.ToJsonString($jsonOptions) + "`n"
+Write-Utf8NoBomFile -Path $hooksJsonPath -Content $content
+
+if ($hooksJsonFileExisted) {
+	Write-Host "Updated '$hooksJsonDisplayPath' with the dotnet-format hook."
+}
+else {
+	Write-Host "Created '$hooksJsonDisplayPath' with the dotnet-format hook."
+}

--- a/conventions/copilot-dotnet-format-hook/dotnet-format.ps1
+++ b/conventions/copilot-dotnet-format-hook/dotnet-format.ps1
@@ -1,0 +1,14 @@
+#requires -PSEdition Core
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$hookInput = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$toolArgs = $hookInput.toolArgs | ConvertFrom-Json
+$toolName = $hookInput.toolName
+$path = $toolArgs.path
+
+if (($toolName -eq 'edit' -or $toolName -eq 'create') -and $path -and $path.EndsWith('.cs')) {
+	$relativePath = [System.IO.Path]::GetRelativePath($PWD, $path)
+	& dotnet format --include $relativePath
+}

--- a/conventions/copilot-dotnet-standards/README.md
+++ b/conventions/copilot-dotnet-standards/README.md
@@ -1,0 +1,36 @@
+# copilot-dotnet-standards
+
+A composite convention that sets up Copilot for .NET development in one step.
+
+## What this convention does
+
+Applies three conventions in order:
+
+1. **`apm-install`** — Installs `LogosBible/AgentConfiguration/common/dotnet-standards`, which provides Copilot instruction files for C# coding standards.
+2. **`copilot-lsp-csharp`** — Configures the Roslyn language server in `.github/lsp.json` so Copilot has code intelligence for C#.
+3. **`copilot-dotnet-format-hook`** — Deploys a `postToolUse` hook that runs `dotnet format` on every `.cs` file the agent edits or creates.
+
+## Settings
+
+None. This convention has no configurable settings.
+
+## Usage
+
+Add to your repository's `.github/conventions.yml`:
+
+```yaml
+conventions:
+  - path: Faithlife/CodingGuidelines/conventions/copilot-dotnet-standards
+```
+
+Then apply:
+
+```pwsh
+repo-conventions apply
+```
+
+## See also
+
+- [`copilot-dotnet-format-hook`](../copilot-dotnet-format-hook/README.md) — add only the format hook without the other components.
+- [`copilot-lsp-csharp`](../copilot-lsp-csharp/README.md) — add only the Roslyn LSP configuration.
+- See [RepoConventions README](../../README.md) for general usage.

--- a/conventions/copilot-dotnet-standards/convention.yml
+++ b/conventions/copilot-dotnet-standards/convention.yml
@@ -1,0 +1,7 @@
+conventions:
+  - path: ../apm-install
+    settings:
+      packages:
+        - LogosBible/AgentConfiguration/common/dotnet-standards
+  - path: ../copilot-lsp-csharp
+  - path: ../copilot-dotnet-format-hook


### PR DESCRIPTION
## Summary

Adds two new conventions:

### `copilot-dotnet-format-hook`
Deploys a Copilot `postToolUse` hook that automatically runs `dotnet format` on any `.cs` file after the agent edits or creates it.

- Copies `dotnet-format.ps1` → `.github/hooks/scripts/dotnet-format.ps1`
- Merges the hook entry into `.github/hooks/hooks.json` (creates the file if absent; preserves existing entries)
- Idempotent
- 4 Pester tests: fresh repo, merge with existing hooks, idempotency, second-run idempotency

### `copilot-dotnet-standards`
A composite convention that sets up Copilot for .NET in one step:
1. `apm-install` — installs `LogosBible/AgentConfiguration/common/dotnet-standards` (instruction files)
2. `copilot-lsp-csharp` — configures the Roslyn LSP server
3. `copilot-dotnet-format-hook` — deploys the format hook