### PR TITLE
Add C# LSP to dotnet-common

### DIFF
--- a/conventions/dotnet-common/convention.yml
+++ b/conventions/dotnet-common/convention.yml
@@ -1,5 +1,6 @@
 conventions:
   - path: ../gitattributes-lf
+  - path: ../copilot-lsp-csharp
   - path: ../dotnet-sdk-10
   - path: ../dotnet-slnx
   - path: ../editorconfig-root


### PR DESCRIPTION
When installing `common/dotnet` or `common/dotnet-aspire` no C# LSP is installed (but a TypeScript one is). This fixes that.