### PR TITLE
Replace nuget-config packageSources while preserving mappings

### DIFF
--- a/conventions/nuget-config/README.md
+++ b/conventions/nuget-config/README.md
@@ -1,12 +1,14 @@
 # nuget-config
 
-Creates or replaces the repository-root `nuget.config` from [files/nuget.config](./files/nuget.config).
+Creates or updates the repository-root `nuget.config` to ensure it uses the standard package sources.
 
 ## Behavior
 
-The published `nuget.config` matches the RepoConventions version except that it omits the `protocolVersion` attribute.
+When no `nuget.config` exists, the convention creates one from [files/nuget.config](./files/nuget.config), which configures `nuget.org` and the Faithlife Azure Artifacts feed as the standard package sources.
 
-If the repository already has a root `nuget.config` and it does not match exactly, the convention replaces it with the published file.
+When a `nuget.config` already exists, the convention replaces only the `<packageSources>` element to match the published template. All other sections — including `<packageSourceMapping>` and `<activePackageSource>` — are preserved. This allows each repository to maintain its own package source mappings, which vary by the private packages each project consumes.
+
+If the file exists but is not valid XML, or does not contain a `<packageSources>` element, the convention throws an error.
 
 ## Example
 

--- a/conventions/nuget-config/convention.Tests.ps1
+++ b/conventions/nuget-config/convention.Tests.ps1
@@ -95,11 +95,11 @@ Describe 'nuget-config convention' {
 		}
 	}
 
-	It 'replaces an existing different nuget.config' {
+	It 'replaces packageSources and preserves all other sections' {
 		$testDirectory = New-TemporaryDirectory
 
 		try {
-			# Arrange a repository with a committed divergent NuGet config.
+			# Arrange a config like LogosCompilerService— custom mappings, old protocolVersion.
 			Initialize-TestRepository -Path $testDirectory
 			$nuGetConfigPath = Join-Path $testDirectory 'nuget.config'
 			$existingContent = @"
@@ -107,7 +107,19 @@ Describe 'nuget-config convention' {
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Faithlife Azure" value="https://pkgs.dev.azure.com/Faithlife/Packages/_packaging/main/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="Faithlife Azure">
+      <package pattern="Argus.*" />
+      <package pattern="Faithlife.*" />
+      <package pattern="OrdersApi.*" />
+      <package pattern="RoyaltyApi.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>
 "@
 			[System.IO.File]::WriteAllText($nuGetConfigPath, $existingContent, $utf8)
@@ -121,15 +133,20 @@ Describe 'nuget-config convention' {
 				Pop-Location
 			}
 
-			# Apply the convention and collect the modified config state.
+			# Apply the convention and inspect the result.
 			$output = InvokeNuGetConfigConvention -TestDirectory $testDirectory
 			$status = @(Get-GitStatusLines -TestDirectory $testDirectory)
+			$updatedDoc = [System.Xml.XmlDocument]::new()
+			$updatedDoc.LoadXml((Get-Content -LiteralPath $nuGetConfigPath -Raw))
 
-			# Assert the config was replaced with the published file.
-			(Get-Content -LiteralPath $nuGetConfigPath -Raw) | Should -Be (Get-Content -LiteralPath $expectedNuGetConfigPath -Raw)
-			$status.Count | Should -Be 1
+			# Assert packageSources updated (clear added, no protocolVersion) and mapping preserved.
+			($null -ne $updatedDoc.DocumentElement.SelectSingleNode('packageSources/clear')) | Should -Be $true
+			($null -eq $updatedDoc.DocumentElement.SelectSingleNode('packageSources/add[@key="nuget.org"]/@protocolVersion')) | Should -Be $true
+			$azurePatterns = @($updatedDoc.DocumentElement.SelectNodes('packageSourceMapping/packageSource[@key="Faithlife Azure"]/package') | ForEach-Object { $_.GetAttribute('pattern') })
+			$azurePatterns | Should -Contain 'OrdersApi.*'
+			$azurePatterns | Should -Contain 'RoyaltyApi.*'
 			$status[0] | Should -Match '^ M nuget\.config$'
-			(@($output | ForEach-Object { $_.ToString() }) -contains "Replaced '$nuGetConfigPath' with the published NuGet config.") | Should -Be $true
+			(@($output | ForEach-Object { $_.ToString() }) -contains "Updated package sources in '$nuGetConfigPath'.") | Should -Be $true
 		}
 		finally {
 			Remove-Item -LiteralPath $testDirectory -Recurse -Force

--- a/conventions/nuget-config/convention.ps1
+++ b/conventions/nuget-config/convention.ps1
@@ -56,16 +56,77 @@ if ($existingNuGetConfigItem.Name -cne 'nuget.config') {
 	$existingNuGetConfigItem = Get-Item -LiteralPath $targetNuGetConfigPath
 }
 
-# Exit when the target already matches the published template.
-if (Test-FileContentMatches -ExpectedPath $sourceNuGetConfigPath -ActualPath $targetNuGetConfigPath) {
+# Load the published package sources and the existing NuGet config as XML documents.
+$sourceDoc = [System.Xml.XmlDocument]::new()
+$sourceDoc.Load($sourceNuGetConfigPath)
+$sourcePackageSources = $sourceDoc.DocumentElement.SelectSingleNode('packageSources')
+
+$targetContent = [System.IO.File]::ReadAllText($targetNuGetConfigPath)
+$targetDoc = [System.Xml.XmlDocument]::new()
+
+try {
+	$targetDoc.LoadXml($targetContent)
+}
+catch {
+	throw "Cannot update '$targetNuGetConfigPath' because it is not valid XML: $_"
+}
+
+$targetPackageSources = $targetDoc.DocumentElement.SelectSingleNode('packageSources')
+
+if ($null -eq $targetPackageSources) {
+	throw "Cannot update '$targetNuGetConfigPath' because it does not contain a <packageSources> element."
+}
+
+# Serialize a packageSources node to a canonical string for comparison.
+function ConvertPackageSourcesToString {
+	param(
+		[Parameter(Mandatory = $true)]
+		[System.Xml.XmlNode] $Node
+	)
+
+	$stringWriter = [System.IO.StringWriter]::new()
+	$settings = [System.Xml.XmlWriterSettings]::new()
+	$settings.Indent = $true
+	$settings.IndentChars = '  '
+	$settings.OmitXmlDeclaration = $true
+	$settings.NewLineChars = "`n"
+	$settings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+
+	$writer = [System.Xml.XmlWriter]::Create($stringWriter, $settings)
+	$Node.WriteTo($writer)
+	$writer.Flush()
+	return $stringWriter.ToString()
+}
+
+# Exit when the existing packageSources already matches the published template.
+$sourcePackageSourcesText = ConvertPackageSourcesToString -Node $sourcePackageSources
+$targetPackageSourcesText = ConvertPackageSourcesToString -Node $targetPackageSources
+
+if ($sourcePackageSourcesText -ceq $targetPackageSourcesText) {
 	return
 }
 
-# Replace stale NuGet config content with the published template.
-$copyResult = Copy-FileIfDifferent -SourcePath $sourceNuGetConfigPath -DestinationPath $targetNuGetConfigPath
+# Replace only the packageSources element, preserving all other sections.
+$importedPackageSources = $targetDoc.ImportNode($sourcePackageSources, $true)
+$targetDoc.DocumentElement.ReplaceChild($importedPackageSources, $targetPackageSources) | Out-Null
 
-if (-not $copyResult.Updated) {
-	throw "Expected '$targetNuGetConfigPath' to be replaced."
+$xmlSettings = [System.Xml.XmlWriterSettings]::new()
+$xmlSettings.Indent = $true
+$xmlSettings.IndentChars = '  '
+$xmlSettings.Encoding = $utf8
+$xmlSettings.NewLineChars = "`n"
+$xmlSettings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+
+# Write the updated document.
+$stream = [System.IO.MemoryStream]::new()
+$xmlWriter = [System.Xml.XmlWriter]::Create($stream, $xmlSettings)
+$targetDoc.Save($xmlWriter)
+$xmlWriter.Flush()
+$newContent = $utf8.GetString($stream.ToArray())
+
+if ($newContent -ceq $targetContent) {
+	return
 }
 
-Write-Host "Replaced '$targetNuGetConfigPath' with the published NuGet config."
+[System.IO.File]::WriteAllText($targetNuGetConfigPath, $newContent, $utf8)
+Write-Host "Updated package sources in '$targetNuGetConfigPath'."

--- a/conventions/nuget-config/files/nuget.config
+++ b/conventions/nuget-config/files/nuget.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Faithlife Azure" value="https://pkgs.dev.azure.com/Faithlife/Packages/_packaging/main/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The `nuget-config` convention replaced the entire `nuget.config` file on any mismatch. Repos that have a `<packageSourceMapping>` section (required when using Azure Artifacts) would have it silently destroyed every time the convention ran.

This came up in the LogosCompilerService repo: https://github.com/LogosBible/LogosCompilerService/blob/master/nuget.config

## Why not just bake all mappings into the convention?

We could as an alternative approach, but it would introduce quite a bit of noise about unrelated dependencies across all our repos. There are many different private packages.

- **LogosCompilerService**: `OrdersApi.*`, `RoyaltyApi.*`, `Argus.*`
- **AcademicProgramApi**: `AccountingApi.*`, `titanic`, `Faithlife.AiApi.*`
- **ProclaimServices**: `Proclaim.*`, `ProclaimSignalR.*`, `SubscriptionsApi.v1.Client`

## What changed

**`convention.ps1`** — Instead of a byte-for-byte file comparison and full replacement, the convention now uses `XmlDocument` to compare and replace only the `<packageSources>` element. All other sections (`<packageSourceMapping>`, `<activePackageSource>`, etc.) are left untouched.

**`files/nuget.config`** — The published template now includes `<clear />` and the Faithlife Azure Artifacts feed.

### Why `<clear />`?

Without `<clear />`, NuGet inherits any machine-level or user-level package sources configured in global `NuGet.config` files. This can cause builds to resolve packages from unexpected sources, making builds non-reproducible across machines. `<clear />` ensures only the explicitly listed sources are used.