### PR TITLE
Update dotnet-common-props metadata defaults

### DIFF
--- a/conventions/dotnet-common-props/README.md
+++ b/conventions/dotnet-common-props/README.md
@@ -4,7 +4,7 @@ Manages shared package repository properties in `Directory.Build.props` and cent
 
 ## Behavior
 
-This convention writes one managed XML property group before the closing `Project` element in `Directory.Build.props`. Repository-specific `VersionPrefix`, `PackageValidationBaselineVersion`, `NoWarn`, `GitHubOrganization`, and `RepositoryName` properties remain outside the managed section. Nullable is enabled in the managed section, and individual projects can override it when necessary.
+This convention writes one managed XML property group before the closing `Project` element in `Directory.Build.props`. Repository-specific `VersionPrefix`, `PackageValidationBaselineVersion`, `NoWarn`, `GitHubOrganization`, `RepositoryName`, and package license properties remain outside the managed section. Package project URL, package release notes, and authors default from the repository identity only when the repository has not already set them. Nullable is enabled in the managed section, and individual projects can override it when necessary.
 
 It also writes managed XML sections in `Directory.Packages.props` for central package management properties and shared analyzer `GlobalPackageReference` items. Repository-specific `PackageVersion` items remain outside the managed sections so libraries can own their dependency versions.
 

--- a/conventions/dotnet-common-props/convention.Tests.ps1
+++ b/conventions/dotnet-common-props/convention.Tests.ps1
@@ -74,10 +74,14 @@ conventions:
 			$buildPropsContent | Should -Match '<VersionPrefix>1.2.3</VersionPrefix>'
 			$buildPropsContent | Should -Match '<PackageValidationBaselineVersion>1.2.0</PackageValidationBaselineVersion>'
 			$buildPropsContent | Should -Match '<NoWarn>\$\(NoWarn\);1591;1998</NoWarn>'
+			$buildPropsContent | Should -Match ([regex]::Escape('<PackageProjectUrl Condition=" ''$(PackageProjectUrl)'' == '''' ">https://github.com/$(GitHubOrganization)/$(RepositoryName)</PackageProjectUrl>'))
+			$buildPropsContent | Should -Match ([regex]::Escape('<PackageReleaseNotes Condition=" ''$(PackageReleaseNotes)'' == '''' ">https://github.com/$(GitHubOrganization)/$(RepositoryName)/blob/master/ReleaseNotes.md</PackageReleaseNotes>'))
+			$buildPropsContent | Should -Match ([regex]::Escape('<Authors Condition=" ''$(Authors)'' == '''' ">$(GitHubOrganization)</Authors>'))
 			$buildPropsContent | Should -Match '(?s)<!-- DO NOT EDIT: dotnet-common-props convention -->.*<Nullable>enable</Nullable>.*<RepositoryUrl>https://github.com/\$\(GitHubOrganization\)/\$\(RepositoryName\)\.git</RepositoryUrl>.*<EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>.*<DisablePackageBaselineValidation Condition=" \$\(PackageValidationBaselineVersion\) == \$\(VersionPrefix\) or \$\(PackageValidationBaselineVersion\) == ''0.0.0'' ">true</DisablePackageBaselineValidation>.*<NuGetAuditLevel>low</NuGetAuditLevel>.*<!-- END DO NOT EDIT -->'
 			$buildPropsContent | Should -Not -Match '(?s)<!-- DO NOT EDIT: dotnet-common-props convention -->.*<VersionPrefix>'
 			$buildPropsContent | Should -Not -Match '(?s)<!-- DO NOT EDIT: dotnet-common-props convention -->.*<PackageValidationBaselineVersion>'
 			$buildPropsContent | Should -Not -Match '(?s)<!-- DO NOT EDIT: dotnet-common-props convention -->.*<NoWarn>'
+			$buildPropsContent | Should -Not -Match '(?s)<!-- DO NOT EDIT: dotnet-common-props convention -->.*<PackageLicenseExpression>'
 
 			# Assert repository-owned package versions remain outside the managed package props sections.
 			$packagePropsContent | Should -Match '<PackageVersion Include="Example" Version="1.0.0" />'
@@ -115,11 +119,13 @@ conventions:
 
 			# Assert the fixed managed properties are present and repository-specific values are absent.
 			$buildPropsContent | Should -Match '<Nullable>enable</Nullable>'
+			$buildPropsContent | Should -Match ([regex]::Escape('<Authors Condition=" ''$(Authors)'' == '''' ">$(GitHubOrganization)</Authors>'))
 			$buildPropsContent | Should -Match '<EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>'
 			$buildPropsContent | Should -Match '<DisablePackageBaselineValidation Condition=" \$\(PackageValidationBaselineVersion\) == \$\(VersionPrefix\) or \$\(PackageValidationBaselineVersion\) == ''0.0.0'' ">true</DisablePackageBaselineValidation>'
 			$buildPropsContent | Should -Not -Match '<VersionPrefix>'
 			$buildPropsContent | Should -Not -Match 'PackageValidationBaselineVersion</PackageValidationBaselineVersion>'
 			$buildPropsContent | Should -Not -Match 'NoWarn'
+			$buildPropsContent | Should -Not -Match '<PackageLicenseExpression>'
 			$packagePropsContent | Should -Match '<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>'
 			$packagePropsContent | Should -Match '<GlobalPackageReference Include="Faithlife.Analyzers" Version="1\.\*" />'
 		}

--- a/conventions/dotnet-common-props/files/properties.xml
+++ b/conventions/dotnet-common-props/files/properties.xml
@@ -5,11 +5,10 @@
   <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   <NeutralLanguage>en-US</NeutralLanguage>
   <DebugType>embedded</DebugType>
-  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  <PackageProjectUrl>https://github.com/$(GitHubOrganization)/$(RepositoryName)</PackageProjectUrl>
-  <PackageReleaseNotes>https://github.com/$(GitHubOrganization)/$(RepositoryName)/blob/master/ReleaseNotes.md</PackageReleaseNotes>
+  <PackageProjectUrl Condition=" '$(PackageProjectUrl)' == '' ">https://github.com/$(GitHubOrganization)/$(RepositoryName)</PackageProjectUrl>
+  <PackageReleaseNotes Condition=" '$(PackageReleaseNotes)' == '' ">https://github.com/$(GitHubOrganization)/$(RepositoryName)/blob/master/ReleaseNotes.md</PackageReleaseNotes>
   <RepositoryUrl>https://github.com/$(GitHubOrganization)/$(RepositoryName).git</RepositoryUrl>
-  <Authors>Faithlife</Authors>
+  <Authors Condition=" '$(Authors)' == '' ">$(GitHubOrganization)</Authors>
   <Copyright>Copyright $(Authors)</Copyright>
   <EnableNETAnalyzers>true</EnableNETAnalyzers>
   <AnalysisLevel>latest-all</AnalysisLevel>


### PR DESCRIPTION
## Summary
- make PackageProjectUrl and PackageReleaseNotes conditional defaults
- default Authors from GitHubOrganization only when Authors is unset
- stop managing PackageLicenseExpression in dotnet-common-props

## Testing
- Invoke-Pester -Path .\conventions\dotnet-common-props\convention.Tests.ps1
- Parsed changed Directory.Build.props consumers as XML
- Ran git diff --check